### PR TITLE
Infer return type for useEnvironmentVariable

### DIFF
--- a/src/Hooks/useEnvironmentVariable.ts
+++ b/src/Hooks/useEnvironmentVariable.ts
@@ -11,7 +11,7 @@ const RequestsMapper = {
 
 export interface TypesMap {
   [EnvironmentVariableTypes.Boolean]: Boolean;
-  [EnvironmentVariableTypes.DataSource]: JSONValue;
+  [EnvironmentVariableTypes.DataSource]: string;
   [EnvironmentVariableTypes.JSON]: JSONValue;
   [EnvironmentVariableTypes.Number]: Number;
   [EnvironmentVariableTypes.String]: string;

--- a/src/Hooks/useEnvironmentVariable.ts
+++ b/src/Hooks/useEnvironmentVariable.ts
@@ -9,7 +9,16 @@ const RequestsMapper = {
     [EnvironmentVariableTypes.DataSource] : EnvironmentVariable.getString
 }*/
 
-export const useEnvironmentVariable = <T  extends string | Number | Boolean | JSONValue = string >(webAPI: any, name: string, type: EnvironmentVariableTypes)=> {  
+export interface TypesMap {
+  [EnvironmentVariableTypes.Boolean]: Boolean;
+  [EnvironmentVariableTypes.DataSource]: JSONValue;
+  [EnvironmentVariableTypes.JSON]: JSONValue;
+  [EnvironmentVariableTypes.Number]: Number;
+  [EnvironmentVariableTypes.String]: string;
+}
+
+export const useEnvironmentVariable = 
+<TInput extends EnvironmentVariableTypes, T extends TypesMap[TInput]>(webAPI: any, name: string, type: TInput)=> {  
   const [envVar, setEnvVar] = useState<EnvironmentVariableType<T> | undefined >();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string|undefined>();


### PR DESCRIPTION
During your presentation you mentioned that you have to specify the return type for the `useEnvironmentVariable` hook. This solution infers the return type based on the type argument `type`.